### PR TITLE
fixing linux sleep call

### DIFF
--- a/source/display.c
+++ b/source/display.c
@@ -279,7 +279,7 @@ void drawFramebuffer(void) {
 			
 			mtime = (seconds * 1000 + useconds / (1000.0 * 1000.0));
 			
-			if(mtime < 1.0 / 60.0) Sleep(1 / 60.0 - mtime);
+			if(mtime < 1.0 / 60.0) sleep(1 / 60.0 - mtime);
 			
 			clock_gettime(CLOCK_MONOTONIC, &frameStart);
 		#endif


### PR DESCRIPTION
Sleep() is a Windows API function. It does not exist in linux. 
The original make file failed to compile display.c due to this undefined reference on my Ubuntu 14.04 box. This fix allows the project to be buildable on linux systems.
